### PR TITLE
Explicitly show support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
   - "pypy"
 # command to install dependencies
 install: "pip install -r requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,13 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
Python-semver is Python3-compatible, but it doesn't explicitly state so in `setup.py`.

I was warned about this in my project that uses python-semver: https://caniusepython3.com/check/00276696-d27c-46f0-b10e-0c7bd684f786
