### PR TITLE
Include README.md in the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst
+include README.md


### PR DESCRIPTION
Installation is failing because the `MANIFEST.in` file does not contain `README.md`. This PR fixes that.