### PR TITLE
Fix a bug with comparing rc0 vs rc1

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -32,7 +32,7 @@ def parse(version):
 def compare(ver1, ver2):
     def nat_cmp(a, b):
         a, b = a or '', b or ''
-        convert = lambda text: text.isdigit() and int(text) or text.lower()
+        convert = lambda text: int(text) if text.isdigit() else text.lower()
         alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
         return cmp(alphanum_key(a), alphanum_key(b))
 


### PR DESCRIPTION
Fixed an issue when I'm trying to compare('0.10.1-rc1', '0.10.1-rc0')