### PR TITLE
Fix bug in comparision between versions with build and prerelease

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -43,15 +43,21 @@ def compare(ver1, ver2):
             v = cmp(d1.get(key), d2.get(key))
             if v:
                 return v
+
         rc1, rc2 = d1.get('prerelease'), d2.get('prerelease')
         rccmp = nat_cmp(rc1, rc2)
-        if not (rc1 or rc2):
-            return rccmp
-        if not rc1:
+
+        build_1, build_2 = d1.get('build'), d2.get('build')
+        build_cmp = nat_cmp(build_1, build_2)
+
+        if not rccmp and not build_cmp:
+            return 0
+        if not rc1 and not build_1:
             return 1
-        elif not rc2:
+        elif not rc2 and not build_2:
             return -1
-        return rccmp or 0
+
+        return rccmp or build_cmp
 
     v1, v2 = parse(ver1), parse(ver2)
 

--- a/tests/semver_test.py
+++ b/tests/semver_test.py
@@ -93,7 +93,14 @@ class TestSemver(TestCase):
         self.assertEqual(compare('1.0.0-rc.1+build.1', '1.0.0'), -1)
 
     def test_should_say_equal_versions_are_equal(self):
-        self.assertEqual(compare("2.0.0", "2.0.0"), 0)
+        self.assertEqual(compare('2.0.0', '2.0.0'), 0)
+        self.assertEqual(compare('1.1.9-rc.1', '1.1.9-rc.1'), 0)
+        self.assertEqual(compare('1.1.9+build.1', '1.1.9+build.1'), 0)
+        self.assertEqual(compare('1.1.9-rc.1+build.1', '1.1.9-rc.1+build.1'), 0)
+
+    def test_should_compare_versions_with_build_and_release(self):
+        self.assertEqual(compare('1.1.9-rc.1', '1.1.9-rc.1+build.1'), -1)
+        self.assertEqual(compare('1.1.9-rc.1', '1.1.9+build.1'), 1)
 
     def test_should_correctly_format_version(self):
         self.assertEqual(format_version(3, 4, 5), '3.4.5')


### PR DESCRIPTION
I found a bug when versions with RC and build numbers were compared, for example:
```
>>> compare('1.1.9-rc.1', '1.1.9+build.1')
-1
>>> compare('1.1.9-rc.1', '1.1.9-rc.1+build.1')
0
```
It seems like comparision for build values was not implemented, so I added this in my PR :)