### PR TITLE
Support matching 'not equal' with '!='

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -83,7 +83,8 @@ def match(version, match_expr):
         match_version = match_expr[1:]
     else:
         raise ValueError("match_expr parameter should be in format <op><ver>, "
-                         "where <op> is one of ['<', '>', '==', '<=', '>=', '!=']. "
+                         "where <op> is one of "
+                         "['<', '>', '==', '<=', '>=', '!=']. "
                          "You provided: %r" % match_expr)
 
     possibilities_dict = {

--- a/semver.py
+++ b/semver.py
@@ -76,20 +76,21 @@ def compare(ver1, ver2):
 
 def match(version, match_expr):
     prefix = match_expr[:2]
-    if prefix in ('>=', '<=', '=='):
+    if prefix in ('>=', '<=', '==', '!='):
         match_version = match_expr[2:]
-    elif prefix and prefix[0] in ('>', '<', '='):
+    elif prefix and prefix[0] in ('>', '<'):
         prefix = prefix[0]
         match_version = match_expr[1:]
     else:
         raise ValueError("match_expr parameter should be in format <op><ver>, "
-                         "where <op> is one of ['<', '>', '==', '<=', '>=']. "
+                         "where <op> is one of ['<', '>', '==', '<=', '>=', '!=']. "
                          "You provided: %r" % match_expr)
 
     possibilities_dict = {
         '>': (1,),
         '<': (-1,),
         '==': (0,),
+        '!=': (-1, 1),
         '>=': (0, 1),
         '<=': (-1, 0)
     }

--- a/tests.py
+++ b/tests.py
@@ -49,6 +49,31 @@ def test_should_no_match_simple():
     assert match("2.3.7", ">=2.3.8") is False
 
 
+def test_should_match_not_equal():
+    assert match("2.3.7", "!=2.3.8") is True
+    assert match("2.3.7", "!=2.3.6") is True
+    assert match("2.3.7", "!=2.3.7") is False
+
+
+def test_should_not_raise_value_error_for_expected_match_expression():
+    assert match("2.3.7", "<2.4.0") is True
+    assert match("2.3.7", ">2.3.5") is True
+
+    assert match("2.3.7", "<=2.3.9") is True
+    assert match("2.3.7", ">=2.3.5") is True
+    assert match("2.3.7", "==2.3.7") is True
+    assert match("2.3.7", "!=2.3.7") is False
+
+
+def test_should_raise_value_error_for_unexpected_match_expression():
+    with pytest.raises(ValueError):
+        match("2.3.7", "=2.3.7")
+    with pytest.raises(ValueError):
+        match("2.3.7", "~2.3.7")
+    with pytest.raises(ValueError):
+        match("2.3.7", "^2.3.7")
+
+
 def test_should_raise_value_error_for_zero_prefixed_versions():
     with pytest.raises(ValueError):
         parse("01.2.3")


### PR DESCRIPTION
Match versions with a match expression meaning 'not equal', for example to explicitly exclude a specific version.

Remove check for unused/unsupported match expression '='.