### PR TITLE
Remove comparison of build metadata

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -57,17 +57,14 @@ def compare(ver1, ver2):
         rc1, rc2 = d1.get('prerelease'), d2.get('prerelease')
         rccmp = nat_cmp(rc1, rc2)
 
-        build_1, build_2 = d1.get('build'), d2.get('build')
-        build_cmp = nat_cmp(build_1, build_2)
-
-        if not rccmp and not build_cmp:
+        if not rccmp:
             return 0
-        if not rc1 and not build_1:
+        if not rc1:
             return 1
-        elif not rc2 and not build_2:
+        elif not rc2:
             return -1
 
-        return rccmp or build_cmp
+        return rccmp
 
     v1, v2 = parse(ver1), parse(ver2)
 

--- a/tests.py
+++ b/tests.py
@@ -126,6 +126,7 @@ def test_should_compare_rc_builds():
 
 
 def test_should_compare_release_candidate_with_release():
+    assert compare('1.0.0-rc.1', '1.0.0') == -1
     assert compare('1.0.0-rc.1+build.1', '1.0.0') == -1
 
 
@@ -137,8 +138,15 @@ def test_should_say_equal_versions_are_equal():
 
 
 def test_should_compare_versions_with_build_and_release():
-    assert compare('1.1.9-rc.1', '1.1.9-rc.1+build.1') == -1
-    assert compare('1.1.9-rc.1', '1.1.9+build.1') == 1
+    assert compare('1.1.9-rc.1', '1.1.9-rc.1+build.1') == 0
+    assert compare('1.1.9-rc.1', '1.1.9+build.1') == -1
+
+
+def test_should_ignore_builds_on_compare():
+    assert compare('1.0.0+build.1', '1.0.0') == 0
+    assert compare('1.0.0-alpha.1+build.1', '1.0.0-alpha.1') == 0
+    assert compare('1.0.0+build.1', '1.0.0-alpha.1') == 1
+    assert compare('1.0.0+build.1', '1.0.0-alpha.1+build.1') == 1
 
 
 def test_should_correctly_format_version():


### PR DESCRIPTION
According to [Semantic Versioning 2.0.0](http://semver.org/):

> 10. ... Build metadata SHOULD be ignored when determining version precedence. ...
>
> 11. ... Precedence MUST be calculated by separating the version into major, minor, patch and pre-release identifiers in that order (Build metadata does not figure into precedence). ...

See spec items [10](http://semver.org/#spec-item-10) and [11](http://semver.org/#spec-item-11).

Changelog:

* Remove build metadata comparison in `compare_by_keys`
* Update `test_should_compare_versions_with_build_and_release`
* Add `test_should_ignore_builds_on_compare`