### PR TITLE
Add support for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     tests_require=['tox', 'virtualenv<14.0.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     flake8
-    py{26,27,32,33,34,35}
+    py{26,27,32,33,34,35,36}
     pypy
 
 [testenv]


### PR DESCRIPTION
Python 3.6 seems to be supported out of the box by library, I think it'll be nice to add official support for this version.