### PR TITLE
Fix problem in `compare` when prerelease tag starts with number followed by letters

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -130,7 +130,7 @@ def parse_version_info(version):
 
 def _nat_cmp(a, b):
     def convert(text):
-        return int(text) if re.match('[0-9]+', text) else text
+        return int(text) if re.match('^[0-9]+$', text) else text
 
     def split_key(key):
         return [convert(c) for c in key.split('.')]

--- a/tests.py
+++ b/tests.py
@@ -331,3 +331,10 @@ def test_should_compare_version_dictionaries():
     assert v1 < v4
     assert v1 <= v4
     assert not(v1 == v4)
+
+
+def test_should_compare_prerelease_with_numbers_and_letters():
+    v1 = VersionInfo(major=1, minor=9, patch=1, prerelease='1unms', build=None)
+    v2 = VersionInfo(major=1, minor=9, patch=1, prerelease=None, build='1asd')
+    assert v1 < v2
+    assert compare("1.9.1-1unms", "1.9.1+1") == -1


### PR DESCRIPTION
It looks like there were missing regex anchors for start/end line. I added them and test to verify fix.