### PR TITLE
support custom default names for pre and build

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -328,7 +328,7 @@ def bump_patch(version):
                           verinfo['patch'] + 1)
 
 
-def bump_prerelease(version):
+def bump_prerelease(version, token='rc'):
     """Raise the prerelease part of the version
 
     :param: version string
@@ -336,12 +336,12 @@ def bump_prerelease(version):
     :rtype: str
     """
     verinfo = parse(version)
-    verinfo['prerelease'] = _increment_string(verinfo['prerelease'] or 'rc.0')
+    verinfo['prerelease'] = _increment_string(verinfo['prerelease'] or token + '.0')
     return format_version(verinfo['major'], verinfo['minor'], verinfo['patch'],
                           verinfo['prerelease'])
 
 
-def bump_build(version):
+def bump_build(version, token='build'):
     """Raise the build part of the version
 
     :param: version string
@@ -349,6 +349,6 @@ def bump_build(version):
     :rtype: str
     """
     verinfo = parse(version)
-    verinfo['build'] = _increment_string(verinfo['build'] or 'build.0')
+    verinfo['build'] = _increment_string(verinfo['build'] or token + '.0')
     return format_version(verinfo['major'], verinfo['minor'], verinfo['patch'],
                           verinfo['prerelease'], verinfo['build'])

--- a/semver.py
+++ b/semver.py
@@ -336,7 +336,9 @@ def bump_prerelease(version, token='rc'):
     :rtype: str
     """
     verinfo = parse(version)
-    verinfo['prerelease'] = _increment_string(verinfo['prerelease'] or token + '.0')
+    verinfo['prerelease'] = _increment_string(
+        verinfo['prerelease'] or token + '.0'
+    )
     return format_version(verinfo['major'], verinfo['minor'], verinfo['patch'],
                           verinfo['prerelease'])
 

--- a/semver.py
+++ b/semver.py
@@ -331,13 +331,14 @@ def bump_patch(version):
 def bump_prerelease(version, token='rc'):
     """Raise the prerelease part of the version
 
-    :param: version string
+    :param version: version string
+    :param token: defaults to 'rc'
     :return: the raised version string
     :rtype: str
     """
     verinfo = parse(version)
     verinfo['prerelease'] = _increment_string(
-        verinfo['prerelease'] or token + '.0'
+        verinfo['prerelease'] or (token or 'rc') + '.0'
     )
     return format_version(verinfo['major'], verinfo['minor'], verinfo['patch'],
                           verinfo['prerelease'])
@@ -346,11 +347,14 @@ def bump_prerelease(version, token='rc'):
 def bump_build(version, token='build'):
     """Raise the build part of the version
 
-    :param: version string
+    :param version: version string
+    :param token: defaults to 'build'
     :return: the raised version string
     :rtype: str
     """
     verinfo = parse(version)
-    verinfo['build'] = _increment_string(verinfo['build'] or token + '.0')
+    verinfo['build'] = _increment_string(
+        verinfo['build'] or (token or 'build') + '.0'
+    )
     return format_version(verinfo['major'], verinfo['minor'], verinfo['patch'],
                           verinfo['prerelease'], verinfo['build'])

--- a/tests.py
+++ b/tests.py
@@ -260,6 +260,7 @@ def test_prerelease_order():
 def test_should_bump_prerelease():
     assert bump_prerelease('3.4.5-rc.9') == '3.4.5-rc.10'
     assert bump_prerelease('3.4.5') == '3.4.5-rc.1'
+    assert bump_prerelease('3.4.5', 'dev') == '3.4.5-dev.1'
 
 
 def test_should_ignore_build_on_prerelease_bump():
@@ -271,6 +272,7 @@ def test_should_bump_build():
     assert bump_build('3.4.5-rc.1+0009.dev') == '3.4.5-rc.1+0010.dev'
     assert bump_build('3.4.5-rc.1') == '3.4.5-rc.1+build.1'
     assert bump_build('3.4.5') == '3.4.5+build.1'
+    assert bump_build('3.4.5', 'nightly') == '3.4.5+nightly.1'
 
 
 def test_should_compare_version_info_objects():

--- a/tests.py
+++ b/tests.py
@@ -261,6 +261,7 @@ def test_should_bump_prerelease():
     assert bump_prerelease('3.4.5-rc.9') == '3.4.5-rc.10'
     assert bump_prerelease('3.4.5') == '3.4.5-rc.1'
     assert bump_prerelease('3.4.5', 'dev') == '3.4.5-dev.1'
+    assert bump_prerelease('3.4.5', '') == '3.4.5-rc.1'
 
 
 def test_should_ignore_build_on_prerelease_bump():
@@ -273,6 +274,7 @@ def test_should_bump_build():
     assert bump_build('3.4.5-rc.1') == '3.4.5-rc.1+build.1'
     assert bump_build('3.4.5') == '3.4.5+build.1'
     assert bump_build('3.4.5', 'nightly') == '3.4.5+nightly.1'
+    assert bump_build('3.4.5', '') == '3.4.5+build.1'
 
 
 def test_should_compare_version_info_objects():


### PR DESCRIPTION
e.g. `dev` instead of `rc` or `nightly` instead of `build`