### PR TITLE
MANIFEST.in: include the license text in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENSE.txt


### PR DESCRIPTION
Several variants of the BSD license exist, so include the actual license
text in sdist for clarity.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>