### PR TITLE
Improve test_immutable function

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -94,22 +94,37 @@ class VersionInfo(object):
     @property
     def major(self):
         return self._major
+    @major.setter
+    def major(self, value):
+        raise AttributeError("attribute 'major' is readonly")
 
     @property
     def minor(self):
         return self._minor
+    @minor.setter
+    def minor(self, value):
+        raise AttributeError("attribute 'minor' is readonly")
 
     @property
     def patch(self):
         return self._patch
+    @patch.setter
+    def patch(self, value):
+        raise AttributeError("attribute 'patch' is readonly")
 
     @property
     def prerelease(self):
         return self._prerelease
+    @prerelease.setter
+    def prerelease(self, value):
+        raise AttributeError("attribute 'prerelease' is readonly")
 
     @property
     def build(self):
         return self._build
+    @build.setter
+    def build(self, value):
+        raise AttributeError("attribute 'build' is readonly")
 
     def _astuple(self):
         return (self.major, self.minor, self.patch,

--- a/semver.py
+++ b/semver.py
@@ -94,6 +94,7 @@ class VersionInfo(object):
     @property
     def major(self):
         return self._major
+
     @major.setter
     def major(self, value):
         raise AttributeError("attribute 'major' is readonly")
@@ -101,6 +102,7 @@ class VersionInfo(object):
     @property
     def minor(self):
         return self._minor
+
     @minor.setter
     def minor(self, value):
         raise AttributeError("attribute 'minor' is readonly")
@@ -108,6 +110,7 @@ class VersionInfo(object):
     @property
     def patch(self):
         return self._patch
+
     @patch.setter
     def patch(self, value):
         raise AttributeError("attribute 'patch' is readonly")
@@ -115,6 +118,7 @@ class VersionInfo(object):
     @property
     def prerelease(self):
         return self._prerelease
+
     @prerelease.setter
     def prerelease(self, value):
         raise AttributeError("attribute 'prerelease' is readonly")
@@ -122,6 +126,7 @@ class VersionInfo(object):
     @property
     def build(self):
         return self._build
+
     @build.setter
     def build(self, value):
         raise AttributeError("attribute 'build' is readonly")

--- a/test_semver.py
+++ b/test_semver.py
@@ -426,21 +426,27 @@ def test_immutable_major(version):
     with pytest.raises(AttributeError, match="attribute 'major' is readonly"):
         version.major = 9
 
+
 def test_immutable_minor(version):
     with pytest.raises(AttributeError, match="attribute 'minor' is readonly"):
         version.minor = 9
+
 
 def test_immutable_patch(version):
     with pytest.raises(AttributeError, match="attribute 'patch' is readonly"):
         version.patch = 9
 
+
 def test_immutable_prerelease(version):
-    with pytest.raises(AttributeError, match="attribute 'prerelease' is readonly"):
+    with pytest.raises(AttributeError,
+                       match="attribute 'prerelease' is readonly"):
         version.prerelease = 'alpha.9.9'
+
 
 def test_immutable_build(version):
     with pytest.raises(AttributeError, match="attribute 'build' is readonly"):
         version.build = 'build.99.e0f985a'
+
 
 def test_immutable_unknown_attribute(version):
     # "no new attribute can be set"

--- a/test_semver.py
+++ b/test_semver.py
@@ -23,6 +23,12 @@ SEMVERFUNCS = [
 ]
 
 
+@pytest.fixture
+def version():
+    return VersionInfo(major=1, minor=2, patch=3,
+                       prerelease='alpha.1.2', build='build.11.e0f985a')
+
+
 @pytest.mark.parametrize("func", SEMVERFUNCS,
                          ids=[func.__name__ for func in SEMVERFUNCS])
 def test_fordocstrings(func):
@@ -416,47 +422,27 @@ def test_parse_method_for_version_info():
     assert str(v) == s_version
 
 
-def test_immutable():
-    v = VersionInfo(major=1, minor=2, patch=3,
-                    prerelease='alpha.1.2', build='build.11.e0f985a')
-    try:
-        v.major = 9
-    except AttributeError:
-        pass
-    else:
-        assert 0, "attribute 'major' must be readonly"
+def test_immutable_major(version):
+    with pytest.raises(AttributeError, match="attribute 'major' is readonly"):
+        version.major = 9
 
-    try:
-        v.minor = 9
-    except AttributeError:
-        pass
-    else:
-        assert 0, "attribute 'minor' must be readonly"
+def test_immutable_minor(version):
+    with pytest.raises(AttributeError, match="attribute 'minor' is readonly"):
+        version.minor = 9
 
-    try:
-        v.patch = 9
-    except AttributeError:
-        pass
-    else:
-        assert 0, "attribute 'patch' must be readonly"
+def test_immutable_patch(version):
+    with pytest.raises(AttributeError, match="attribute 'patch' is readonly"):
+        version.patch = 9
 
-    try:
-        v.prerelease = 'alpha.9.9'
-    except AttributeError:
-        pass
-    else:
-        assert 0, "attribute 'prerelease' must be readonly"
+def test_immutable_prerelease(version):
+    with pytest.raises(AttributeError, match="attribute 'prerelease' is readonly"):
+        version.prerelease = 'alpha.9.9'
 
-    try:
-        v.build = 'build.99.e0f985a'
-    except AttributeError:
-        pass
-    else:
-        assert 0, "attribute 'build' must be readonly"
+def test_immutable_build(version):
+    with pytest.raises(AttributeError, match="attribute 'build' is readonly"):
+        version.build = 'build.99.e0f985a'
 
-    try:
-        v.new_attribute = 'forbidden'
-    except AttributeError:
-        pass
-    else:
-        assert 0, "no new attribute can be set"
+def test_immutable_unknown_attribute(version):
+    # "no new attribute can be set"
+    with pytest.raises(AttributeError):
+        version.new_attribute = 'forbidden'


### PR DESCRIPTION
This PR contains the following changes:

* Raise `AttributeError` with useful messages for major, minor, patch, prerelease, and build attributes.
* Use [`pytest.raises` ](https://docs.pytest.org/en/latest/reference.html?highlight=pytest.raises#pytest-raises) which replace and shorten the `try..except..else` blocks.
* Use `match` keyword in pytest.raises which matches the `AttributeError` from the property setter.
* Split `test_immutable` into several different test functions,  e.g.` test_immutable_major`.

Some comments:

* I've splitted the `test_immutable` function into several other functions as IMHO it makes it more readable.
* If you don't like the property setter and prefer a more cleaner class, I can remove it. I merely added them to have a more correct error message raised which can be tested against.
* The `test_immutable` function could also be parametrized by the `@pytest.mark.parametrize` decorator. However, I've decided against it as the attributes to test are manageable and probably won't change.
* The `test_immutable_unknown_attribute` function just raises the `AttributeError` exception, no error message is checked (like with `test_immutable_major`). I left that out and only checked against the exception.

Hope you like it. :wink: 