### PR TITLE
Use python3 instead of python3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
 
 [testenv:flake8]
-basepython = python3.4
+basepython = python3
 deps = flake8
 commands = flake8


### PR DESCRIPTION
Fix #121. Reduce command `python3.3` to `python3`.

With that patch, it works on Travis and locally. I consider the latter as essential as it doesn't force the user to have Python 3.4 installed. Every 3.x version is possible as long there is an executable or link to `python3`.