### PR TITLE
Fixes #109 and add iterator to VersionInfo

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,7 +29,7 @@ Significant contributors
 * Craig Blaszczyk <masterjakul@gmail.com>
 * Jan Pieter Waagmeester <jieter@jieter.nl>
 * Jelo Agnasin <jelo@icannhas.com>
-* Karol Werner <karol.werner@codete.co>
+* Karol Werner <karol.werner@ppkt.eu>
 * Peter Bittner <django@bittner.it>
 * robi-wan <robi-wan@suyu.de>
 * T. Jameson Little <t.jameson.little@gmail.com>

--- a/semver.py
+++ b/semver.py
@@ -155,6 +155,12 @@ class VersionInfo(object):
             ("build", self.build)
         ))
 
+    def __iter__(self):
+        """Implement iter(self)."""
+        # As long as we support Py2.7, we can't use the "yield from" syntax
+        for v in self._astuple():
+            yield v
+
     @comparator
     def __eq__(self, other):
         return _compare_by_keys(self._asdict(), _to_dict(other)) == 0

--- a/test_semver.py
+++ b/test_semver.py
@@ -452,3 +452,8 @@ def test_immutable_unknown_attribute(version):
     # "no new attribute can be set"
     with pytest.raises(AttributeError):
         version.new_attribute = 'forbidden'
+
+
+def test_version_info_should_be_iterable(version):
+    assert tuple(version) == (version.major, version.minor, version.patch,
+                              version.prerelease, version.build)


### PR DESCRIPTION
This PR is based on #109 by Karol Werner and contains:

* Add Karl to the `CONTRIBUTORS` file and added him as primary author.
* Use `version` fixture in test function `test_version_info_should_be_iterable`.
* I've deviated from Karl's test function a bit and avoided the "private" `_astuple()` function and created the tuple manually.
* This PR does not contains a conflict. :wink: 

I think, Karol's idea is useful as it allows to create a list with just `tuple(version)` or `list(version)` without using the (kind of) "private" member function `_astuple()`.

If the maintainers of this project find it useful, I suggest to close #109 as well (as it is related and contains a conflict).
