### PR TITLE
Create setup.cfg for pytest & tox config and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+# https://pytest-cov.readthedocs.io/
+
+[run]
+source = semver
+branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .egg/
+norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .eggs/
 addopts =
     -q
     --no-cov-on-fail

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[tool:pytest]
+norecursedirs = .git build .env/ env/ .pyenv/ .tmp/
+addopts =
+    -q
+    --no-cov-on-fail
+    --cov=semver
+    --cov-report=term-missing
+    --doctest-modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .eggs/
 addopts =
     -q
+    --ignore=.eggs/
     --no-cov-on-fail
     --cov=semver
     --cov-report=term-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-norecursedirs = .git build .env/ env/ .pyenv/ .tmp/
+norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .egg/
 addopts =
     -q
     --no-cov-on-fail

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pypy
 
 [testenv]
-commands = pytest
+commands = py.test
 deps =
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,10 @@ envlist =
     pypy
 
 [testenv]
-commands = py.test -q  --doctest-modules
-deps = pytest
+commands = pytest
+deps =
+    pytest
+    pytest-cov
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
 


### PR DESCRIPTION
This PR contains the following changes:

* Use `pytest` command instead of `py.test` (the latter with the dot may be obsolete in the future).
* Move options from `tox.ini` to `setup.cfg`.
* Introduce `pytest-cov` in "tox.ini" for coverage and config file `.coveragerc`
* Add additional options to activate coverage for `semver.py` script and output coverage report

---

Some comments:

* It simplifies the `tox.ini` config. Well, it's probably a matter of taste where do you want to have all your options. However, if you add it to `setup.cfg`, you can also add options for `flake8`. That way, you have everything in **one place**.
* I'm not sure if coverage is useful for such a small script. To have an oversight of which lines are not covered by tests yet *could* be useful. At the moment I get:

```
----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name        Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------
semver.py     186      1     48      3    96%   82, 379, 540-541, 37->42, 81->82, 378->379, 434->438, 539->540
```

Decide yourself if you think this could be useful. If you don't like it, I can change it or just close this PR. :wink: 