### PR TITLE
Fix #126: Provide tox.ini for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,6 @@ texinfo_documents = [
 ]
 
 
-interpshinx_mapping = {
+intersphinx_mapping = {
     "matplotlib": ('http://matplotlib.org', None),
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# requirements file for documentation
+sphinx
+sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,9 @@ setenv =
 basepython = python3
 deps = flake8
 commands = flake8
+
+[testenv:docs]
+basepython = python3
+deps = -r{toxinidir}/docs/requirements.txt
+skip_install = true
+commands = sphinx-build {posargs:-E} -b html docs dist/docs


### PR DESCRIPTION
This PR contains the following change and fixes #126 :

* Add "docs" target to run sphinx and output HTML
* Provide `docs/requirements.txt` file
* Fix typo in `docs/conf.py`

----

Some comments:

* You could run the `docs` target through Travis, same as with the other targets. However, I wasn't sure if this would be useful for you, because you may create the doc with something else.
* I've provided a separate requirements.txt file only for documentation. That way you can add whatever is needed without changing the `tox.ini` file.
* The result of the build can be found at `dist/docs`.
