### PR TITLE
Fix #135, convert prerelease and build to string

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -102,8 +102,8 @@ class VersionInfo(object):
         self._major = major
         self._minor = minor
         self._patch = patch
-        self._prerelease = prerelease
-        self._build = build
+        self._prerelease = None if prerelease is None else str(prerelease)
+        self._build = None if build is None else str(build)
 
     @property
     def major(self):

--- a/semver.py
+++ b/semver.py
@@ -99,9 +99,9 @@ class VersionInfo(object):
     __slots__ = ('_major', '_minor', '_patch', '_prerelease', '_build')
 
     def __init__(self, major, minor=0, patch=0, prerelease=None, build=None):
-        self._major = major
-        self._minor = minor
-        self._patch = patch
+        self._major = int(major)
+        self._minor = int(minor)
+        self._patch = int(patch)
         self._prerelease = None if prerelease is None else str(prerelease)
         self._build = None if build is None else str(build)
 

--- a/test_semver.py
+++ b/test_semver.py
@@ -499,13 +499,9 @@ def test_version_info_should_be_iterable(version):
                               version.prerelease, version.build)
 
 
-@pytest.mark.parametrize("v1,v2", [
-  # no. 1
-  ({'major': 1, 'minor': 9, 'patch': 1, 'prerelease': 1, 'build': 1},
-   {'major': 1, 'minor': 9, 'patch': 1, 'prerelease': 2, 'build': 1}),
-  # no. 2
-  ({'major': 3, 'minor': 2, 'patch': 1, 'prerelease': 1},
-   {'major': 3, 'minor': 2, 'patch': 1, 'prerelease': 3}),
-])
-def test_should_compare_prerelease_and_build_with_numbers(v1, v2):
-    assert VersionInfo(**v1) < VersionInfo(**v2)
+def test_should_compare_prerelease_and_build_with_numbers():
+    assert VersionInfo(major=1, minor=9, patch=1, prerelease=1, build=1) < \
+           VersionInfo(major=1, minor=9, patch=1, prerelease=2, build=1)
+    assert VersionInfo(1, 9, 1, 1, 1) < VersionInfo(1, 9, 1, 2, 1)
+    assert VersionInfo('2') < VersionInfo(10)
+    assert VersionInfo('2') < VersionInfo('10')

--- a/test_semver.py
+++ b/test_semver.py
@@ -514,10 +514,11 @@ def test_should_be_able_to_use_strings_as_major_minor_patch():
     assert isinstance(v.patch, int)
     assert v.prerelease is None
     assert v.build is None
+    assert v == VersionInfo(1, 2, 3)
+    assert VersionInfo(1, 2, 3, 4, 5) == VersionInfo(1, 2, 3, '4', '5')
 
 
 def test_should_be_able_to_use_integers_as_prerelease_build():
     v = VersionInfo('1', '2', '3', 4, 5)
     assert isinstance(v.prerelease, str)
     assert isinstance(v.build, str)
-    assert VersionInfo('1', '2', '3') == VersionInfo(1, 2, 3)

--- a/test_semver.py
+++ b/test_semver.py
@@ -514,11 +514,20 @@ def test_should_be_able_to_use_strings_as_major_minor_patch():
     assert isinstance(v.patch, int)
     assert v.prerelease is None
     assert v.build is None
-    assert v == VersionInfo(1, 2, 3)
-    assert VersionInfo(1, 2, 3, 4, 5) == VersionInfo(1, 2, 3, '4', '5')
+    assert VersionInfo('1', '2', '3') == VersionInfo(1, 2, 3)
+
+
+def test_using_non_numeric_string_as_major_minor_patch_throws():
+    with pytest.raises(ValueError):
+        v = VersionInfo('a')
+    with pytest.raises(ValueError):
+        v = VersionInfo(1, 'a')
+    with pytest.raises(ValueError):
+        v = VersionInfo(1, 2, 'a')
 
 
 def test_should_be_able_to_use_integers_as_prerelease_build():
-    v = VersionInfo('1', '2', '3', 4, 5)
+    v = VersionInfo(1, 2, 3, 4, 5)
     assert isinstance(v.prerelease, str)
     assert isinstance(v.build, str)
+    assert VersionInfo(1, 2, 3, 4, 5) == VersionInfo(1, 2, 3, '4', '5')

--- a/test_semver.py
+++ b/test_semver.py
@@ -505,3 +505,19 @@ def test_should_compare_prerelease_and_build_with_numbers():
     assert VersionInfo(1, 9, 1, 1, 1) < VersionInfo(1, 9, 1, 2, 1)
     assert VersionInfo('2') < VersionInfo(10)
     assert VersionInfo('2') < VersionInfo('10')
+
+
+def test_should_be_able_to_use_strings_as_major_minor_patch():
+    v = VersionInfo('1', '2', '3')
+    assert isinstance(v.major, int)
+    assert isinstance(v.minor, int)
+    assert isinstance(v.patch, int)
+    assert v.prerelease is None
+    assert v.build is None
+
+
+def test_should_be_able_to_use_integers_as_prerelease_build():
+    v = VersionInfo('1', '2', '3', 4, 5)
+    assert isinstance(v.prerelease, str)
+    assert isinstance(v.build, str)
+    assert VersionInfo('1', '2', '3') == VersionInfo(1, 2, 3)

--- a/test_semver.py
+++ b/test_semver.py
@@ -499,7 +499,13 @@ def test_version_info_should_be_iterable(version):
                               version.prerelease, version.build)
 
 
-def test_should_compare_prerelease_and_build_with_numbers():
-    v1 = VersionInfo(major=1, minor=9, patch=1, prerelease=1, build=1)
-    v2 = VersionInfo(major=1, minor=9, patch=1, prerelease=2, build=1)
-    assert v1 < v2
+@pytest.mark.parametrize("v1,v2", [
+  # no. 1
+  ({'major': 1, 'minor': 9, 'patch': 1, 'prerelease': 1, 'build': 1},
+   {'major': 1, 'minor': 9, 'patch': 1, 'prerelease': 2, 'build': 1}),
+  # no. 2
+  ({'major': 3, 'minor': 2, 'patch': 1, 'prerelease': 1},
+   {'major': 3, 'minor': 2, 'patch': 1, 'prerelease': 3}),
+])
+def test_should_compare_prerelease_and_build_with_numbers(v1, v2):
+    assert VersionInfo(**v1) < VersionInfo(**v2)

--- a/test_semver.py
+++ b/test_semver.py
@@ -497,3 +497,9 @@ def test_immutable_unknown_attribute(version):
 def test_version_info_should_be_iterable(version):
     assert tuple(version) == (version.major, version.minor, version.patch,
                               version.prerelease, version.build)
+
+
+def test_should_compare_prerelease_and_build_with_numbers():
+    v1 = VersionInfo(major=1, minor=9, patch=1, prerelease=1, build=1)
+    v2 = VersionInfo(major=1, minor=9, patch=1, prerelease=2, build=1)
+    assert v1 < v2

--- a/test_semver.py
+++ b/test_semver.py
@@ -519,11 +519,11 @@ def test_should_be_able_to_use_strings_as_major_minor_patch():
 
 def test_using_non_numeric_string_as_major_minor_patch_throws():
     with pytest.raises(ValueError):
-        v = VersionInfo('a')
+        VersionInfo('a')
     with pytest.raises(ValueError):
-        v = VersionInfo(1, 'a')
+        VersionInfo(1, 'a')
     with pytest.raises(ValueError):
-        v = VersionInfo(1, 2, 'a')
+        VersionInfo(1, 2, 'a')
 
 
 def test_should_be_able_to_use_integers_as_prerelease_build():


### PR DESCRIPTION
This PR fixes #135 

Creating `VersionInfo(3, 2, 1, 1)` succeeds, but fails later when comparing it with another `VersionInfo` instance (for example, v1 < v2):

```
    def split_key(key):
>       return [convert(c) for c in key.split('.')]
E       AttributeError: 'int' object has no attribute 'split'
```