### PR TITLE
Implement #139: Bump version inside VersionInfo

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -164,6 +164,74 @@ class VersionInfo(object):
         for v in self._astuple():
             yield v
 
+    def bump_major(self):
+        """Raise the major part of the version
+
+        :return: the raised version string
+        :rtype: VersionInfo
+
+        >>> import semver
+        >>> ver = semver.parse_version_info("3.4.5")
+        >>> ver.bump_major()
+        VersionInfo(major=4, minor=0, patch=0, prerelease=None, build=None)
+        """
+        return parse_version_info(bump_major(str(self)))
+
+    def bump_minor(self):
+        """Raise the minor part of the version
+
+        :return: the raised version string
+        :rtype: VersionInfo
+
+        >>> import semver
+        >>> ver = semver.parse_version_info("3.4.5")
+        >>> ver.bump_minor()
+        VersionInfo(major=3, minor=5, patch=0, prerelease=None, build=None)
+        """
+        return parse_version_info(bump_minor(str(self)))
+
+    def bump_patch(self):
+        """Raise the patch part of the version
+
+        :return: the raised version string
+        :rtype: VersionInfo
+
+        >>> import semver
+        >>> ver = semver.parse_version_info("3.4.5")
+        >>> ver.bump_patch()
+        VersionInfo(major=3, minor=4, patch=6, prerelease=None, build=None)
+        """
+        return parse_version_info(bump_patch(str(self)))
+
+    def bump_prerelease(self, token='rc'):
+        """Raise the prerelease part of the version
+
+        :param token: defaults to 'rc'
+        :return: the raised version string
+        :rtype: str
+
+        >>> import semver
+        >>> ver = semver.parse_version_info("3.4.5-rc.1")
+        >>> ver.bump_prerelease()
+        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.2', build=None)
+        """
+        return parse_version_info(bump_prerelease(str(self), token))
+
+
+    def bump_build(self, token='build'):
+        """Raise the build part of the version
+
+        :param token: defaults to 'build'
+        :return: the raised version string
+        :rtype: str
+
+        >>> import semver
+        >>> ver = semver.parse_version_info("3.4.5-rc.1+build.9")
+        >>> ver.bump_build()
+        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.1', build='build.10')
+        """
+        return parse_version_info(bump_build(str(self), token))
+
     @comparator
     def __eq__(self, other):
         return _compare_by_keys(self._asdict(), _to_dict(other)) == 0

--- a/semver.py
+++ b/semver.py
@@ -165,9 +165,10 @@ class VersionInfo(object):
             yield v
 
     def bump_major(self):
-        """Raise the major part of the version
+        """Raise the major part of the version, return a new object
+           but leave self untouched
 
-        :return: the raised version string
+        :return: new object with the raised major part
         :rtype: VersionInfo
 
         >>> import semver
@@ -178,9 +179,10 @@ class VersionInfo(object):
         return parse_version_info(bump_major(str(self)))
 
     def bump_minor(self):
-        """Raise the minor part of the version
+        """Raise the minor part of the version, return a new object
+           but leave self untouched
 
-        :return: the raised version string
+        :return: new object with the raised minor part
         :rtype: VersionInfo
 
         >>> import semver
@@ -191,9 +193,10 @@ class VersionInfo(object):
         return parse_version_info(bump_minor(str(self)))
 
     def bump_patch(self):
-        """Raise the patch part of the version
+        """Raise the patch part of the version, return a new object
+           but leave self untouched
 
-        :return: the raised version string
+        :return: new object with the raised patch part
         :rtype: VersionInfo
 
         >>> import semver
@@ -204,10 +207,11 @@ class VersionInfo(object):
         return parse_version_info(bump_patch(str(self)))
 
     def bump_prerelease(self, token='rc'):
-        """Raise the prerelease part of the version
+        """Raise the prerelease part of the version, return a new object
+           but leave self untouched
 
         :param token: defaults to 'rc'
-        :return: the raised version string
+        :return: new object with the raised prerelease part
         :rtype: str
 
         >>> import semver
@@ -218,12 +222,12 @@ build=None)
         """
         return parse_version_info(bump_prerelease(str(self), token))
 
-
     def bump_build(self, token='build'):
-        """Raise the build part of the version
+        """Raise the build part of the version, return a new object
+           but leave self untouched
 
         :param token: defaults to 'build'
-        :return: the raised version string
+        :return: new object with the raised build part
         :rtype: str
 
         >>> import semver

--- a/semver.py
+++ b/semver.py
@@ -213,7 +213,8 @@ class VersionInfo(object):
         >>> import semver
         >>> ver = semver.parse_version_info("3.4.5-rc.1")
         >>> ver.bump_prerelease()
-        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.2', build=None)
+        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.2', \
+build=None)
         """
         return parse_version_info(bump_prerelease(str(self), token))
 
@@ -228,7 +229,8 @@ class VersionInfo(object):
         >>> import semver
         >>> ver = semver.parse_version_info("3.4.5-rc.1+build.9")
         >>> ver.bump_build()
-        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.1', build='build.10')
+        VersionInfo(major=3, minor=4, patch=5, prerelease='rc.1', \
+build='build.10')
         """
         return parse_version_info(bump_build(str(self), token))
 

--- a/test_semver.py
+++ b/test_semver.py
@@ -262,6 +262,50 @@ def test_should_bump_minor():
 def test_should_bump_patch():
     assert bump_patch('3.4.5') == '3.4.6'
 
+def test_should_versioninfo_bump_major_and_minor():
+    v = parse_version_info("3.4.5")
+    expected = parse_version_info("4.1.0")
+    assert v.bump_major().bump_minor() == expected
+
+
+def test_should_versioninfo_bump_minor_and_patch():
+    v = parse_version_info("3.4.5")
+    expected = parse_version_info("3.5.1")
+    assert v.bump_minor().bump_patch() == expected
+
+
+def test_should_versioninfo_bump_patch_and_prerelease():
+    v = parse_version_info("3.4.5-rc.1")
+    expected = parse_version_info("3.4.6-rc.1")
+    assert v.bump_patch().bump_prerelease() == expected
+
+
+def test_should_versioninfo_bump_patch_and_prerelease_with_token():
+    v = parse_version_info("3.4.5-dev.1")
+    expected = parse_version_info("3.4.6-dev.1")
+    assert v.bump_patch().bump_prerelease("dev") == expected
+
+
+def test_should_versioninfo_bump_prerelease_and_build():
+    v = parse_version_info("3.4.5-rc.1+build.1")
+    expected = parse_version_info("3.4.5-rc.2+build.2")
+    assert v.bump_prerelease().bump_build() == expected
+
+
+def test_should_versioninfo_bump_prerelease_and_build_with_token():
+    v = parse_version_info("3.4.5-rc.1+b.1")
+    expected = parse_version_info("3.4.5-rc.2+b.2")
+    assert v.bump_prerelease().bump_build("b") == expected
+
+
+def test_should_versioninfo_bump_multiple():
+    v = parse_version_info("3.4.5-rc.1+build.1")
+    expected = parse_version_info("3.4.5-rc.2+build.2")
+    assert v.bump_prerelease().bump_build().bump_build() == expected
+    expected = parse_version_info("3.4.5-rc.3")
+    assert v.bump_prerelease().bump_build().bump_build().bump_prerelease() == \
+        expected
+
 
 def test_should_ignore_extensions_for_bump():
     assert bump_patch('3.4.5-rc1+build4') == '3.4.6'

--- a/test_semver.py
+++ b/test_semver.py
@@ -262,6 +262,7 @@ def test_should_bump_minor():
 def test_should_bump_patch():
     assert bump_patch('3.4.5') == '3.4.6'
 
+
 def test_should_versioninfo_bump_major_and_minor():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("4.1.0")


### PR DESCRIPTION
This PR implements #139 

* Add bump_major, bump_minor, bump_patch, bump_prerelease and bump_build as methods in class VersionInfo. With this methods, it is now possible to write something like this:

    ```python
    ver = semver.parse_version_info("3.4.5")
    new_ver = ver.bump_major().bump_minor()
    ```

* Add test cases

---

Some comments about this implementation:

* I (re)used the module functions `semver.bump_major()` etc. to avoid implementing the same code (double code is bad code).
* It may be not as efficient as it could be, because it converts the VersionInfo into a string, bumps it, and convert is back into VersionInfo. Not sure if there is a better way to do it.
* I've created a "Draft pull request" so we can discuss and improve the code. ;-)

@ppkt Karol, what do you think? :-)