### PR TITLE
Fix #145: add posargs in tox.ini (single test cases)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+# config file for automatic testing at travis-ci.org
 language: python
+cache: pip
 install:
   - pip install --upgrade pip setuptools
   - pip install virtualenv tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 install:
   - pip install --upgrade pip setuptools
   - pip install virtualenv
-script: python setup.py test
+script: tox -v
 matrix:
   include:
   - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 install:
   - pip install --upgrade pip setuptools
-  - pip install virtualenv
+  - pip install virtualenv tox
 script: tox -v
 matrix:
   include:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pypy
 
 [testenv]
-commands = py.test {posargs:}
+commands = pytest {posargs:}
 deps =
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pypy
 
 [testenv]
-commands = py.test
+commands = py.test {posargs:}
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
This PR fixes #145 

Without the posargs argument tox has to run the *complete* test suite. With this patch, you can
pass a test file and a test function. That allows tox to only run this specific test function. For example:

```
$ tox -e py36 test_semver.py::test_should_bump_major
```

Keep in mind, it doesn't change the default behavior. It's just an additional feature if someone wants to run a single test function alone.

This may help to speed up the development a little bit. :wink: 
