### PR TITLE
Improve coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ branch = True
 [report]
 exclude_lines =
     pragma: no cover
+    if __name__ == .__main__.:

--- a/test_semver.py
+++ b/test_semver.py
@@ -316,6 +316,10 @@ def test_should_get_max():
     assert max_ver('3.4.5', '4.0.2') == '4.0.2'
 
 
+def test_should_get_max_same():
+    assert max_ver('3.4.5', '3.4.5') == '3.4.5'
+
+
 def test_should_get_min():
     assert min_ver('3.4.5', '4.0.2') == '3.4.5'
 


### PR DESCRIPTION
This PR is not based on an issue, but it with this change, it raises the coverage level. Currently I get:

```
----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name        Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------
semver.py     198      0     50      2    99%   38->43, 513->517
```

Line 513-517 belongs to the `_increment_string()` function. I wasn't sure how to cover it as it is indirectly called by `bump_prerelease()` and `bump_build()`. Any idea is very appreciated. :+1: 
