### PR TITLE
Fix #136: add testsuite to tar ball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE.txt
+include test_*.py


### PR DESCRIPTION
This PR fixes #136 and adds the `test_semver.py` file into the tarball when running `python setup.py sdist`.

---

Comments:

* I've added a glob pattern in the `MANIFEST.in` file (`test_*.py`) in case we add some more test files. 