### PR TITLE
Invoke clean from distutils before running our code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@ from os import remove
 from os.path import dirname, join
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+try:
+    from setuptools.command.clean import clean as CleanCommand
+except ImportError:
+    from distutils.command.clean import clean as CleanCommand
 from shlex import split
 from shutil import rmtree
 
@@ -30,8 +34,9 @@ class Tox(TestCommand):
         exit(errno)
 
 
-class Clean(TestCommand):
+class Clean(CleanCommand):
     def run(self):
+        super().run()
         delete_in_root = [
             'build',
             '.cache',


### PR DESCRIPTION
Small fix, but should solve problem from #119 - original clean command will be executed before our code so parsing arguments should work as intended.