### PR TITLE
Fix 144: Add replace function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Features
 * :pr:`125`: Created :file:`setup.cfg` for pytest and tox
 * :gh:`126` (:pr:`127`): Added target for documentation in :file:`tox.ini`
 * :gh:`142` (:pr:`143`): Improved usage section
+* :gh:`144` (:pr:`156`): Added :func:`semver.replace` and :func:`semver.VersionInfo.replace`
+  functions
 * :gh:`145` (:pr:`146`): Added posargs in :file:`tox.ini`
 * :pr:`157`: Introduce :file:`conftest.py` to improve doctests
 * :pr:`165`: Improved code coverage

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -118,6 +118,37 @@ In case you need the different parts of a version stepwise, iterate over the :cl
     [3, 4, 5, 'pre.2', 'build.4']
 
 
+Replacing Parts of a Version
+----------------------------
+
+If you want to replace different parts of a version, but leave other parts
+unmodified, use one of the functions :func:`semver.replace` or
+:func:`semver.VersionInfo.replace`:
+
+* From a version string::
+
+   >>> semver.replace("1.4.5-pre.1+build.6", major=2)
+   '2.4.5-pre.1+build.6'
+
+* From a :class:`semver.VersionInfo` instance::
+
+   >>> version = semver.VersionInfo.parse("1.4.5-pre.1+build.6")
+   >>> version.replace(major=2, minor=2)
+   VersionInfo(major=2, minor=2, patch=5, prerelease='pre.1', build='build.6')
+
+If you pass invalid keys you get an exception::
+
+   >>> semver.replace("1.2.3", invalidkey=2)
+   Traceback (most recent call last)
+   ...
+   TypeError: replace() got 1 unexpected keyword argument(s): invalidkey
+   >>> version = semver.VersionInfo.parse("1.4.5-pre.1+build.6")
+   >>> version.replace(invalidkey=2)
+   Traceback (most recent call last)
+   ...
+   TypeError: replace() got 1 unexpected keyword argument(s): invalidkey
+
+
 .. _sec.convert.versions:
 
 Converting Different Version Types

--- a/semver.py
+++ b/semver.py
@@ -292,6 +292,28 @@ prerelease='pre.2', build='build.4')
         """
         return parse_version_info(version)
 
+    def replace(self, **parts):
+        """Replace one or more parts of a version and return a new
+          :class:`semver.VersionInfo` object, but leave self untouched
+
+        :param dict parts: the parts to be updated. Valid keys are:
+          ``major``, ``minor``, ``patch``, ``prerelease``, or ``build``
+        :return: the new :class:`semver.VersionInfo` object with the changed
+          parts
+        :raises: TypeError, if ``parts`` contains invalid keys
+        """
+        version = self._asdict()
+        version.update(parts)
+        try:
+            return VersionInfo(**version)
+        except TypeError:
+            unknownkeys = set(parts) - set(self._asdict())
+            error = ("replace() got %d unexpected keyword "
+                     "argument(s): %s" % (len(unknownkeys),
+                                          ", ".join(unknownkeys))
+                     )
+            raise TypeError(error)
+
 
 def _to_dict(obj):
     if isinstance(obj, VersionInfo):
@@ -702,6 +724,24 @@ def main(cliargs=None):
     except (ValueError, TypeError) as err:
         print("ERROR", err, file=sys.stderr)
         return 2
+
+
+def replace(version, **parts):
+    """Replace one or more parts of a version and return the new string
+
+    :param str version: the version string to replace
+    :param dict parts: the parts to be updated. Valid keys are:
+      ``major``, ``minor``, ``patch``, ``prerelease``, or ``build``
+    :return: the replaced version string
+    :raises: TypeError, if ``parts`` contains invalid keys
+    :rtype: str
+
+    >>> import semver
+    >>> semver.replace("1.2.3", major=2, patch=10)
+    '2.2.10'
+    """
+    version = parse_version_info(version)
+    return str(version.replace(**parts))
 
 
 if __name__ == "__main__":

--- a/test_semver.py
+++ b/test_semver.py
@@ -18,14 +18,15 @@ from semver import (VersionInfo,
                     parse,
                     parse_version_info,
                     process,
+                    replace,
                     )
 
 SEMVERFUNCS = [
     compare, createparser,
     bump_build, bump_major, bump_minor, bump_patch, bump_prerelease,
     finalize_version, format_version,
-    match, max_ver, min_ver, parse, process,
-]
+    match, max_ver, min_ver, parse, process, replace,
+    ]
 
 
 @pytest.mark.parametrize("string,expected", [
@@ -655,3 +656,45 @@ def test_should_process_raise_error(capsys):
     assert rc != 0
     captured = capsys.readouterr()
     assert captured.err.startswith("ERROR")
+
+
+@pytest.mark.parametrize("version,parts,expected", [
+    ("3.4.5", dict(major=2), '2.4.5'),
+    ("3.4.5", dict(major="2"), '2.4.5'),
+    ("3.4.5", dict(major=2, minor=5), '2.5.5'),
+    ("3.4.5", dict(minor=2), '3.2.5'),
+    ("3.4.5", dict(major=2, minor=5, patch=10), '2.5.10'),
+    ("3.4.5", dict(major=2, minor=5, patch=10, prerelease="rc1"),
+     '2.5.10-rc1'),
+    ("3.4.5", dict(major=2, minor=5, patch=10, prerelease="rc1", build="b1"),
+     '2.5.10-rc1+b1'),
+    ("3.4.5-alpha.1.2", dict(major=2), '2.4.5-alpha.1.2'),
+    ("3.4.5-alpha.1.2", dict(build="x1"), '3.4.5-alpha.1.2+x1'),
+    ("3.4.5+build1", dict(major=2), '2.4.5+build1'),
+])
+def test_replace_method_replaces_requested_parts(version, parts, expected):
+    assert replace(version, **parts) == expected
+
+
+def test_replace_raises_TypeError_for_invalid_keyword_arg():
+    with pytest.raises(TypeError, match=r"replace\(\).*unknown.*"):
+        assert replace("1.2.3", unknown="should_raise")
+
+
+@pytest.mark.parametrize("version,parts,expected", [
+    ("3.4.5", dict(major=2, minor=5), '2.5.5'),
+    ("3.4.5", dict(major=2, minor=5, patch=10), '2.5.10'),
+    ("3.4.5-alpha.1.2", dict(major=2), '2.4.5-alpha.1.2'),
+    ("3.4.5-alpha.1.2", dict(build="x1"), '3.4.5-alpha.1.2+x1'),
+    ("3.4.5+build1", dict(major=2), '2.4.5+build1'),
+])
+def test_should_return_versioninfo_with_replaced_parts(version,
+                                                       parts,
+                                                       expected):
+    assert VersionInfo.parse(version).replace(**parts) == \
+           VersionInfo.parse(expected)
+
+
+def test_replace_raises_ValueError_for_non_numeric_values():
+    with pytest.raises(ValueError):
+        VersionInfo.parse("1.2.3").replace(major="x")


### PR DESCRIPTION
This PR fixes #144 and contains:

* `semver.replace(version: str, **parts: dict)`
* `semver.VersionInfo.replace(**parts: dict)`
* Extend the usage documentation
* ~~Adapt `format_version()` function. This function accepts strings in the major, minor, and patch parts now. It was necessary as it makes the implementation of `semver.replace()` a bit easier.~~
* Both `replace()` functions raises a `KeyError` exception if you pass invalid keys. This makes the API consistent. 
  My original implementation just delegate it to the respective function; however, that leads to different exceptions raised (`TypeError` or `ValueError`).

Both do almost the same: it replaces parts of a version string or a `VersionInfo` object and creates a new object (with the changed parts).

**Update 2019-10-12:**

The `format_version()` function does not need to be adapted anymore.