### PR TITLE
Improve doctests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+import semver
+
+
+@pytest.fixture(autouse=True)
+def add_semver(doctest_namespace):
+    doctest_namespace["semver"] = semver

--- a/semver.py
+++ b/semver.py
@@ -49,7 +49,6 @@ def parse(version):
              if not provided
     :rtype: dict
 
-    >>> import semver
     >>> ver = semver.parse('3.4.5-pre.2+build.4')
     >>> ver['major']
     3
@@ -171,7 +170,6 @@ class VersionInfo(object):
         :return: new object with the raised major part
         :rtype: VersionInfo
 
-        >>> import semver
         >>> ver = semver.parse_version_info("3.4.5")
         >>> ver.bump_major()
         VersionInfo(major=4, minor=0, patch=0, prerelease=None, build=None)
@@ -185,7 +183,6 @@ class VersionInfo(object):
         :return: new object with the raised minor part
         :rtype: VersionInfo
 
-        >>> import semver
         >>> ver = semver.parse_version_info("3.4.5")
         >>> ver.bump_minor()
         VersionInfo(major=3, minor=5, patch=0, prerelease=None, build=None)
@@ -199,7 +196,6 @@ class VersionInfo(object):
         :return: new object with the raised patch part
         :rtype: VersionInfo
 
-        >>> import semver
         >>> ver = semver.parse_version_info("3.4.5")
         >>> ver.bump_patch()
         VersionInfo(major=3, minor=4, patch=6, prerelease=None, build=None)
@@ -214,7 +210,6 @@ class VersionInfo(object):
         :return: new object with the raised prerelease part
         :rtype: str
 
-        >>> import semver
         >>> ver = semver.parse_version_info("3.4.5-rc.1")
         >>> ver.bump_prerelease()
         VersionInfo(major=3, minor=4, patch=5, prerelease='rc.2', \
@@ -230,7 +225,6 @@ build=None)
         :return: new object with the raised build part
         :rtype: str
 
-        >>> import semver
         >>> ver = semver.parse_version_info("3.4.5-rc.1+build.9")
         >>> ver.bump_build()
         VersionInfo(major=3, minor=4, patch=5, prerelease='rc.1', \
@@ -277,14 +271,13 @@ build='build.10')
     def parse(version):
         """Parse version string to a VersionInfo instance.
 
-        >>> from semver import VersionInfo
-        >>> VersionInfo.parse('3.4.5-pre.2+build.4')
+        :param version: version string
+        :return: a :class:`semver.VersionInfo` instance
+        :rtype: :class:`semver.VersionInfo`
+
+        >>> semver.VersionInfo.parse('3.4.5-pre.2+build.4')
         VersionInfo(major=3, minor=4, patch=5, \
 prerelease='pre.2', build='build.4')
-
-        :param version: version string
-        :return: a :class:`VersionInfo` instance
-        :rtype: :class:`VersionInfo`
         """
         return parse_version_info(version)
 
@@ -304,7 +297,6 @@ def parse_version_info(version):
     :return: a :class:`VersionInfo` instance
     :rtype: :class:`VersionInfo`
 
-    >>> import semver
     >>> version_info = semver.parse_version_info("3.4.5-pre.2+build.4")
     >>> version_info.major
     3
@@ -380,7 +372,6 @@ def compare(ver1, ver2):
              zero if ver1 == ver2 and strictly positive if ver1 > ver2
     :rtype: int
 
-    >>> import semver
     >>> semver.compare("1.0.0", "2.0.0")
     -1
     >>> semver.compare("2.0.0", "1.0.0")
@@ -408,7 +399,6 @@ def match(version, match_expr):
     :return: True if the expression matches the version, otherwise False
     :rtype: bool
 
-    >>> import semver
     >>> semver.match("2.0.0", ">=1.0.0")
     True
     >>> semver.match("1.0.0", ">1.0.0")
@@ -449,7 +439,6 @@ def max_ver(ver1, ver2):
     :return: the greater version of the two
     :rtype: :class:`VersionInfo`
 
-    >>> import semver
     >>> semver.max_ver("1.0.0", "2.0.0")
     '2.0.0'
     """
@@ -468,7 +457,6 @@ def min_ver(ver1, ver2):
     :return: the smaller version of the two
     :rtype: :class:`VersionInfo`
 
-    >>> import semver
     >>> semver.min_ver("1.0.0", "2.0.0")
     '1.0.0'
     """
@@ -490,7 +478,6 @@ def format_version(major, minor, patch, prerelease=None, build=None):
     :return: the formatted string
     :rtype: str
 
-    >>> import semver
     >>> semver.format_version(3, 4, 5, 'pre.2', 'build.4')
     '3.4.5-pre.2+build.4'
     """
@@ -524,7 +511,6 @@ def bump_major(version):
     :return: the raised version string
     :rtype: str
 
-    >>> import semver
     >>> semver.bump_major("3.4.5")
     '4.0.0'
     """
@@ -539,7 +525,6 @@ def bump_minor(version):
     :return: the raised version string
     :rtype: str
 
-    >>> import semver
     >>> semver.bump_minor("3.4.5")
     '3.5.0'
     """
@@ -554,7 +539,6 @@ def bump_patch(version):
     :return: the raised version string
     :rtype: str
 
-    >>> import semver
     >>> semver.bump_patch("3.4.5")
     '3.4.6'
     """
@@ -571,7 +555,7 @@ def bump_prerelease(version, token='rc'):
     :return: the raised version string
     :rtype: str
 
-    >>> bump_prerelease('3.4.5', 'dev')
+    >>> semver.bump_prerelease('3.4.5', 'dev')
     '3.4.5-dev.1'
     """
     verinfo = parse(version)
@@ -590,7 +574,7 @@ def bump_build(version, token='build'):
     :return: the raised version string
     :rtype: str
 
-    >>> bump_build('3.4.5-rc.1+build.9')
+    >>> semver.bump_build('3.4.5-rc.1+build.9')
     '3.4.5-rc.1+build.10'
     """
     verinfo = parse(version)
@@ -608,7 +592,7 @@ def finalize_version(version):
     :return: the finalized version string
     :rtype: str
 
-    >>> finalize_version('1.2.3-rc.5')
+    >>> semver.finalize_version('1.2.3-rc.5')
     '1.2.3'
     """
     verinfo = parse(version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,4 @@ addopts =
     --cov=semver
     --cov-report=term-missing
     --doctest-modules
+    --doctest-report ndiff


### PR DESCRIPTION
This PR is not based on a specific issue, but contains the following changes:

* Introduce `conftest.py` to add pytest fixture for `doctest_namespace`
  See https://docs.pytest.org/en/latest/doctest.html#doctest-namespace-fixture
* Remove the "import semver" line in each doctest; this is covered in `conftest.py` now as a pytest fixture
* Extend `setup.cfg` with `--doctest-report ndiff`
  Makes the output a bit nicer in case something goes wrong
* Make sure, the docstrings are consistent:
   * First line is a summary
   * Followed by a linebreak and the description of the parameters
   * Optionally with a doctest