### PR TITLE
Improve code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,9 @@ source = semver
 branch = True
 
 [report]
+show_missing = true
+precision = 1
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:
+    if not hasattr\(__builtins__, .cmp.\):

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Features
 * :gh:`142` (:pr:`143`): Improved usage section
 * :gh:`145` (:pr:`146`): Added posargs in :file:`tox.ini`
 * :pr:`157`: Introduce :file:`conftest.py` to improve doctests
+* :pr:`165`: Improved code coverage
 
 Bug Fixes
 ---------

--- a/test_semver.py
+++ b/test_semver.py
@@ -23,6 +23,16 @@ SEMVERFUNCS = [
 ]
 
 
+@pytest.mark.parametrize("string,expected", [
+    ("rc", "rc"),
+    ("rc.1", "rc.2"),
+    ("2x", "3x"),
+])
+def test_should_private_increment_string(string, expected):
+    from semver import _increment_string
+    assert _increment_string(string) == expected
+
+
 @pytest.fixture
 def version():
     return VersionInfo(major=1, minor=2, patch=3,


### PR DESCRIPTION
This PR does not belong to an issue. It contains the following changes:

* Add test for (private) `_increment_string()` function
* Adapt `.coveragerc`:
  * Introduce option precision; 
  * Disable coverage for `cmp()` function

---

With the above modifications, coverage is raised to 100%. :wink: 