### PR TITLE
First GitHub Action to test for test.pypi.org

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+       - name: Install pep517
+      run: >-
+        python3 -m pip install pep517 --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m pep517.build \
+        --source \
+        --binary \
+        --out-dir dist/ .
+    - name: Publish distribution 📦to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+#    - name: Publish distribution 📦to PyPI
+#      if: startsWith(github.event.ref, 'refs/tags')
+#      uses: pypa/gh-action-pypi-publish@master
+#      with:
+#        password: ${{ secrets.pypi_password }}
+


### PR DESCRIPTION
Taken from https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/